### PR TITLE
Add output format option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ event.
 | `include-tag-commit` | whether to include the commit with the current tag                                        | No       | `'true'`                       |
 | `include-hashes`     | whether or not each commit message should be prefixed with the corresponding hash         | No       | `'true'`                       |
 | `line-prefix`        | the prefix to add to every listed commit                                                  | No       | `'- '`                         |
+| `output-format`      | git log format (e.g., "%s (%h)" or "%h %s")                                               | No       | `'%h\ %s'`                         |
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,11 @@ inputs:
     required: false
     default: '- '
 
+  output-format:
+    description: git log format (e.g., "%s (%h)" or "%h %s")
+    required: false
+    default: "%h\ %s"
+
 outputs:
   changes:
     description: collected changes as multiline string
@@ -63,6 +68,7 @@ runs:
         includeTagCommit="${{ inputs.include-tag-commit }}"
         includeHashes="${{ inputs.include-hashes }}"
         linePrefix="${{ inputs.line-prefix }}"
+        outputFormat="${{ inputs.output-format }}"
 
         # fetch all tags from origin
         git fetch origin --tags --force
@@ -107,7 +113,7 @@ runs:
         fi
 
         # get changes for range
-        changes=$(git log --pretty=format:%h\ %s --no-decorate "$range")
+        changes=$(git log --pretty=format:"$outputFormat" --no-decorate "$range")
 
         # optionally remove the commit message tagged with the latest tag
         if [[ "$includeTagCommit" != "true" ]]; then


### PR DESCRIPTION
This PR allows to set a different output format like 
- {commit-message} ({commit-id})