### PR TITLE
Only find tags that exist in the commit history

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -67,8 +67,8 @@ runs:
         # fetch all tags from origin
         git fetch origin --tags --force
 
-        # get tags that match the pattern and sort them using version sorting in reverse
-        tags=$(git tag -l | grep -E "$tagPattern" | sort -Vr || echo "")
+        # get tags that match the pattern and exist in the commit history from current HEAD
+        tags=$(git log --decorate=short --simplify-by-decoration --pretty=format:"%D" | grep -o 'tag:[^,]*' | sed 's/tag: //' | grep -E "$tagPattern" || echo "")
 
         # count the found tags
         countTags=$(echo "$tags" | wc -l)


### PR DESCRIPTION
The current behavior breaks in certain cases.

Example

```
v2.17.12
v2.16.27
v2.16.26
v2.16.25
v2.16.24
```

Running this job on `v2.16.27` will break since it will find `v2.17.12` as the latest tag, even though that exists in another branch. It should find `v2.16.26` which is a direct parent of `v2.16.27`

This PR fixes the behavior, so the list is

```
v2.16.27
v2.16.26
v2.16.25
v2.16.24
```